### PR TITLE
fix no such table error

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ class Request(db.Model):
     platform = db.Column(db.String)
     mimetype = db.Column(db.String)
 
+db.create_all()
+
 statistics = Statistics(app, db, Request)
 
 @app.route("/")


### PR DESCRIPTION
The example given in the README does not work without creating the database first and throws: `(sqlite3.OperationalError) no such table: request`

This may be self-explanatory, but for me it was not, thus I assume it is helpful adding it.